### PR TITLE
Fix typo in README.md and test spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This lab requires you to use specific selectors in your CSS to style the HTML.
 
 #### `*`
 
-Use a global selector to set the font of the page to `"Helvetica", "Arial", "san-serif"`
+Use a global selector to set the font of the page to `"Helvetica", "Arial", "sans-serif"`
 
 
 #### `body`

--- a/spec/icebreakers_homepage_with_css_spec.rb
+++ b/spec/icebreakers_homepage_with_css_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "A Styled IceBreakers Homepage" do
   end
 
   context 'General' do
-    it 'has a global selector to set font-family of "Helvetica", "Arial", "san-serif"' do
+    it 'has a global selector to set font-family of "Helvetica", "Arial", "sans-serif"' do
       css = parse_css_from_file("./style.css")
       global = css["*"]
 


### PR DESCRIPTION
Test and README.md called for improper css property under the global selector of "san-serif" instead of "sans-serif". Added the missing letter in both files.